### PR TITLE
Support futuristic syntax for service injections

### DIFF
--- a/addon/helpers/-translate-dynamic.js
+++ b/addon/helpers/-translate-dynamic.js
@@ -1,0 +1,8 @@
+import { helper } from '@ember/component/helper';
+
+export default helper(function(args) {
+  if (args && typeof args[0] === 'string') {
+    return args[0].replace('::', '@');
+  }
+  return args && args[0];
+});

--- a/index.js
+++ b/index.js
@@ -11,5 +11,10 @@ module.exports = {
         return __dirname;
       }
     });
+  },
+
+  included() {
+    this._super.included.apply(this, arguments);
+    this.import('vendor/service-inject.js');
   }
 };

--- a/lib/namespacing-transform.js
+++ b/lib/namespacing-transform.js
@@ -1,5 +1,23 @@
 'use strict';
 
+const TRANSLATE_HELPER = 'ember-holy-futuristic-template-namespacing-batman@-translate-dynamic';
+
+function rewriteOrWrapComponentParam(node, b) {
+  if (!node.params.length) {
+    return;
+  }
+  let firstParam = node.params[0];
+  if (firstParam.type === 'StringLiteral') {
+    // handle string constant
+    node.params[0] = b.string(firstParam.original.replace('::', '@'));
+    return;
+  }
+  if (firstParam.type === 'PathExpression' || firstParam.type === 'SubExpression') {
+    node.params[0] = b.sexpr(TRANSLATE_HELPER, [firstParam], null, firstParam.loc);
+    return;
+  }
+}
+
 module.exports = class NamespacingTransform {
   constructor(options) {
     this.syntax = null;
@@ -26,6 +44,27 @@ module.exports = class NamespacingTransform {
         if (node.tag.indexOf('::') > -1) {
           node.tag = node.tag.replace('::', '@');
         }
+      },
+      MustacheStatement(node) {
+        if (node.path.original !== 'component') {
+          // we don't care about non-component expressions
+          return;
+        }
+        rewriteOrWrapComponentParam(node, b);
+      },
+      SubExpression(node) {
+        if (node.path.original !== 'component') {
+          // we don't care about non-component expressions
+          return;
+        }
+        rewriteOrWrapComponentParam(node, b);
+      },
+      BlockStatement(node) {
+        if (node.path.original !== 'component') {
+          // we don't care about blocks not using component
+          return;
+        }
+        rewriteOrWrapComponentParam(node, b);
       }
     });
 

--- a/tests/integration/components/test-namespacing-test.js
+++ b/tests/integration/components/test-namespacing-test.js
@@ -1,11 +1,28 @@
 /* globals define */
 import { helper as buildHelper } from '@ember/component/helper';
+import { default as Service, inject } from '@ember/service';
 
 import Component from '@ember/component';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
+
+define('other-namespace/services/some-service', ['exports'], function(exports) {
+  exports.default = Service.extend({
+    text: 'some random text'
+  });
+});
+
+define('other-namespace/templates/components/some-service-thing', ['exports'], function(exports) {
+  exports.default = hbs`{{someService.text}}`;
+});
+
+define('other-namespace/components/some-service-thing', ['exports'], function(exports) {
+  exports.default = Component.extend({
+    someService: inject('other-namespace::some-service'),
+  });
+});
 
 define('other-namespace/templates/components/some-template-thing', ['exports'], function(exports) {
   exports.default = hbs`some-template-thing`;
@@ -16,6 +33,23 @@ define('other-namespace/components/some-js-thing', ['exports'], function(exports
     tagName: 'p',
     classNames: ['some-js-thing']
   });
+});
+
+define('other-namespace/templates/components/some-yield-static', ['exports'], function(exports) {
+  exports.default = hbs`{{yield (component "other-namespace::some-template-thing")}}`;
+});
+
+define('other-namespace/templates/components/some-yield-dynamic', ['exports'], function(exports) {
+  exports.default = hbs`{{yield (component dynamicName)}}`;
+});
+
+define('other-namespace/templates/components/some-yield-helper', ['exports'], function(exports) {
+  exports.default = hbs`
+    {{yield
+      (component
+        (other-namespace::some-helper-thing "other-namespace::some-template-thing")
+      )
+    }}`;
 });
 
 define('other-namespace/helpers/some-helper-thing', ['exports'], function(exports) {
@@ -49,5 +83,93 @@ module('test-namespacing', function(hooks) {
     await render(hbs`<OtherNamespace::SomeJsThing>hi</OtherNamespace::SomeJsThing>`);
 
     assert.equal(find('*').textContent.trim(), 'hi');
+  });
+
+  test('it can render service injection', async function(assert) {
+    await render(hbs`{{other-namespace::some-service-thing}}`);
+
+    assert.equal(find('*').textContent.trim(), 'some random text');
+  });
+
+  test('it can render dynamic component', async function(assert) {
+    this.dynamicName = "other-namespace::some-service-thing";
+    await render(hbs`{{component dynamicName}}`);
+
+    assert.equal(find('*').textContent.trim(), 'some random text');
+  });
+
+  test('it can render component helper with static name', async function(assert) {
+    await render(hbs`{{component "other-namespace::some-service-thing"}}`);
+
+    assert.equal(find('*').textContent.trim(), 'some random text');
+  });
+
+  test('it can render component helper with expression', async function(assert) {
+    await render(hbs`
+      {{component
+        (other-namespace::some-helper-thing "other-namespace::some-service-thing")
+      }}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'some random text');
+  });
+
+  test('it can render component helper in block mode with static name', async function(assert) {
+    await render(hbs`{{#component "other-namespace::some-yield-static" as |cmpt|}}
+                       {{component cmpt}}
+                     {{/component}}`);
+
+    assert.equal(find('*').textContent.trim(), 'some-template-thing');
+  });
+
+  test('it can render component helper in block mode with expression', async function(assert) {
+    await render(hbs`
+      {{#component
+        (other-namespace::some-helper-thing "other-namespace::some-yield-static")
+        as |cmpt|}}
+        {{component cmpt}}
+      {{/component}}
+    `);
+
+    assert.equal(find('*').textContent.trim(), 'some-template-thing');
+  });
+
+  test('it can render component helper in block mode with dynamic name', async function(assert) {
+    this.dynamicName = 'other-namespace::some-yield-static';
+    await render(hbs`{{#component dynamicName as |cmpt|}}
+                       {{component cmpt}}
+                     {{/component}}`);
+
+    assert.equal(find('*').textContent.trim(), 'some-template-thing');
+  });
+
+  test('it can yield component with dynamic name', async function(assert) {
+    await render(
+      hbs`{{#other-namespace::some-yield-dynamic dynamicName="other-namespace::some-template-thing" as |cmpt|}}
+            {{component cmpt}}
+          {{/other-namespace::some-yield-dynamic}}`
+    );
+
+    assert.equal(find('*').textContent.trim(), 'some-template-thing');
+  });
+
+  test('it can yield component with static name', async function(assert) {
+    await render(
+      hbs`{{#other-namespace::some-yield-static  as |cmpt|}}
+            {{component cmpt}}
+          {{/other-namespace::some-yield-static}}`
+    );
+
+    assert.equal(find('*').textContent.trim(), 'some-template-thing');
+  });
+
+  test('it can yield component with expression', async function(assert) {
+    await render(
+      hbs`{{#other-namespace::some-yield-helper  as |cmpt|}}
+            {{component cmpt}}
+          {{/other-namespace::some-yield-helper}}`
+    );
+
+    assert.equal(find('*').textContent.trim(), 'some-template-thing');
   });
 });

--- a/vendor/service-inject.js
+++ b/vendor/service-inject.js
@@ -1,0 +1,11 @@
+/* globals Ember */
+(function() {
+  // eslint-disable-next-line ember/new-module-imports
+  const ORIGINAL_INJECT_SERVICE = Ember.inject.service;
+  // eslint-disable-next-line ember/new-module-imports
+  Ember.inject.service = function(_name) {
+    let name = _name === undefined ? undefined : _name.replace('::', '@');
+    return ORIGINAL_INJECT_SERVICE.call(this, name);
+  };
+})();
+


### PR DESCRIPTION
This works for 2.17 & 2.18. It does not work for 3.2 version.

Unfortunately, we have the logic for handling names in a couple of different places and some of them are little weirder to override than others.

Support for 3.2: it seems the injected property class already handles `::`, but it expects the resolver to support `expandLocalLookup`, which the default ember resolver does not and I'm not sure what is the expectation.