### PR TITLE
Add support for using $ as a separator in addition to `::`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,22 @@
-## 🛑🛑🛑 Module Unification, along with the namespacing style provided by this addon, is no longer being implemented in Ember. Instead, this functionality will be replaced with [template imports](https://github.com/emberjs/rfcs/pull/454), which are still in the process of being designed and RFC'd. It is not recommended that you use this addon. 🛑🛑🛑
+## 🛑🛑🛑 Module Unification is no longer being implemented in Ember. Instead, this functionality will be replaced with [template imports](https://github.com/emberjs/rfcs/pull/454), which are still in the process of being designed and RFC'd. It is not recommended that you use this addon. 🛑🛑🛑
 
 ## If you have already adopted this addon, _don't panic_. We will continue to support it until the migration to template imports has been completed.
 
 ember-holy-futuristic-template-namespacing-batman
 ==============================================================================
 
-This experimental addon allows the usage of `{{some-addon-name::component-name}}` today! 🎉
+This experimental addon allows the usage of two different styles of invoking
+components and helpers using their addons name, by using `$` syntax.
+
+Using a new syntax designed to avoid collisions with how Ember has ultimately
+decided to use `::`: `{{some-addon-name$component-name}}`
+
+*Note:* This addon currently also allows using the `::` syntax that was
+originally proposed in
+[emberjs/rfcs#309](https://github.com/emberjs/rfcs/pull/309) (e.g.
+`{{some-addon-name::component-name}}`), but that functionality will be
+deprecated in future versions in order to avoid collisions with
+[emberjs/rfcs#457](https://github.com/emberjs/rfcs/pull/457).
 
 Installation
 ------------------------------------------------------------------------------
@@ -18,24 +29,28 @@ ember install ember-holy-futuristic-template-namespacing-batman
 Usage
 ------------------------------------------------------------------------------
 
-Allows experimenting with [Module Unification Namespaces RFC](https://github.com/emberjs/rfcs/pull/309) namespacing in your applications today.
-
 - Supports helper invocation:
 
 ```hbs
-{{addon-name::helper-name}}
+{{addon-name$helper-name}}
 ```
 
 - Supports component invocation:
 
 ```hbs
-{{addon-name::component-name}}
+{{addon-name$component-name}}
 ```
 
 - Supports angle bracket invocation (when used with Ember 3.4+ or ember-angle-bracket-invocation-polyfill)
 
 ```hbs
-<AddonName::ComponentName />
+<AddonName$ComponentName />
+```
+
+- Supports nested angle bracket invocation (when used with Ember 3.10+ or ember-angle-bracket-invocation-polyfill)
+
+```hbs
+<AddonName$SomeFolderName::ComponentName />
 ```
 
 Contributing

--- a/addon/helpers/-translate-dynamic.js
+++ b/addon/helpers/-translate-dynamic.js
@@ -2,7 +2,7 @@ import { helper } from '@ember/component/helper';
 
 export default helper(function(args) {
   if (args && typeof args[0] === 'string') {
-    return args[0].replace('::', '@');
+    return args[0].replace('::', '@').replace('$', '@');
   }
   return args && args[0];
 });

--- a/index.js
+++ b/index.js
@@ -14,20 +14,39 @@ module.exports = {
   },
 
   setupPreprocessorRegistry(type, registry) {
-    let pluginObj = this._buildPlugin();
-    pluginObj.parallelBabel = {
+    let dollarPluginObj = this._buildDollarPlugin();
+    dollarPluginObj.parallelBabel = {
       requireFile: __filename,
-      buildUsing: '_buildPlugin',
+      buildUsing: '_buildDollarPlugin',
       params: {}
     }
 
-   registry.add("htmlbars-ast-plugin", pluginObj);
+    registry.add("htmlbars-ast-plugin", dollarPluginObj);
+
+    let colonPluginObj = this._buildColonPlugin();
+    colonPluginObj.parallelBabel = {
+      requireFile: __filename,
+      buildUsing: '_buildColonPlugin',
+      params: {}
+    }
+
+   registry.add("htmlbars-ast-plugin", colonPluginObj);
   },
 
-  _buildPlugin() {
+  _buildDollarPlugin() {
     return {
       name: 'holy-futuristic-template-namespacing-batman',
-      plugin: require("./lib/namespacing-transform"),
+      plugin: require("./lib/namespacing-transform").DollarNamespacingTransform,
+      baseDir: function() {
+        return __dirname;
+      }
+    };
+  },
+
+  _buildColonPlugin() {
+    return {
+      name: 'holy-futuristic-template-namespacing-batman',
+      plugin: require("./lib/namespacing-transform").ColonNamespacingTransform,
       baseDir: function() {
         return __dirname;
       }

--- a/lib/namespacing-transform.js
+++ b/lib/namespacing-transform.js
@@ -2,14 +2,14 @@
 
 const TRANSLATE_HELPER = 'ember-holy-futuristic-template-namespacing-batman@-translate-dynamic';
 
-function rewriteOrWrapComponentParam(node, b) {
+function rewriteOrWrapComponentParam(node, b, sigil) {
   if (!node.params.length) {
     return;
   }
   let firstParam = node.params[0];
   if (firstParam.type === 'StringLiteral') {
     // handle string constant
-    node.params[0] = b.string(firstParam.original.replace('::', '@'));
+    node.params[0] = b.string(firstParam.original.replace(sigil, '@'));
     return;
   }
   if (firstParam.type === 'PathExpression' || firstParam.type === 'SubExpression') {
@@ -18,18 +18,20 @@ function rewriteOrWrapComponentParam(node, b) {
   }
 }
 
-module.exports = class NamespacingTransform {
+class NamespacingTransform {
   constructor(options) {
     this.syntax = null;
     this.options = options;
+    this.sigil = undefined;
   }
 
   transform(ast) {
     const b = this.syntax.builders;
+    let sigil = this.sigil;
 
     this.syntax.traverse(ast, {
       PathExpression(node) {
-        if (node.parts.length > 1 || !node.original.includes('::')) {
+        if (node.parts.length > 1 || !node.original.includes(sigil)) {
           return;
         }
 
@@ -38,11 +40,11 @@ module.exports = class NamespacingTransform {
         if (loc === null) {
           loc = undefined;
         }
-        return b.path(node.original.replace('::', '@'), loc);
+        return b.path(node.original.replace(sigil, '@'), loc);
       },
       ElementNode(node) {
-        if (node.tag.indexOf('::') > -1) {
-          node.tag = node.tag.replace('::', '@');
+        if (node.tag.indexOf(sigil) > -1) {
+          node.tag = node.tag.replace(sigil, '@');
         }
       },
       MustacheStatement(node) {
@@ -50,24 +52,45 @@ module.exports = class NamespacingTransform {
           // we don't care about non-component expressions
           return;
         }
-        rewriteOrWrapComponentParam(node, b);
+        rewriteOrWrapComponentParam(node, b, sigil);
       },
       SubExpression(node) {
         if (node.path.original !== 'component') {
           // we don't care about non-component expressions
           return;
         }
-        rewriteOrWrapComponentParam(node, b);
+        rewriteOrWrapComponentParam(node, b, sigil);
       },
       BlockStatement(node) {
         if (node.path.original !== 'component') {
           // we don't care about blocks not using component
           return;
         }
-        rewriteOrWrapComponentParam(node, b);
+        rewriteOrWrapComponentParam(node, b, sigil);
       }
     });
 
     return ast;
   }
 }
+
+class DollarNamespacingTransform extends NamespacingTransform {
+  constructor(options) {
+    super(options);
+
+    this.sigil = '$';
+  }
+}
+
+class ColonNamespacingTransform extends NamespacingTransform {
+  constructor(options) {
+    super(options);
+
+    this.sigil = '::';
+  }
+}
+
+module.exports = {
+  DollarNamespacingTransform,
+  ColonNamespacingTransform,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4800,9 +4800,9 @@
       }
     },
     "ember-angle-bracket-invocation-polyfill": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-1.2.5.tgz",
-      "integrity": "sha512-fGU8iBwduCmr7TfWpA0VlAhfJJKGVXPyAwxKizRn4/DIEDkS20TWox3XD+B8DCup9VKGiP0UMaXU9NK23xPQMg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/ember-angle-bracket-invocation-polyfill/-/ember-angle-bracket-invocation-polyfill-1.3.1.tgz",
+      "integrity": "sha512-eeE4LBFIxJ5EclTIydPMPs04vvSDv64m+1fxwN2UKdSdRDWwus36k4B/LquDfWuG1WI0Dk3R4WoTFcRYlbNTWg==",
       "dev": true,
       "requires": {
         "ember-cli-babel": "^6.17.0",
@@ -4820,18 +4820,18 @@
           }
         },
         "babel-plugin-ember-modules-api-polyfill": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.6.0.tgz",
-          "integrity": "sha512-BSbLv3+ju1mcUUoPe7vPJgnGawrNxp6LfFBRHlNOKeMlQlml9Wo2MRRUrbpNDlmVc761xSKj8+cde7R0Lwpq7g==",
+          "version": "2.10.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-ember-modules-api-polyfill/-/babel-plugin-ember-modules-api-polyfill-2.10.0.tgz",
+          "integrity": "sha512-dtbzgiewjX0fPj6/cKvzZLu+PSFbbM8Wa2FHR/Xk+Oewpzv1RG8Hm28lqEKoW6Hrmro9AdhWwq+gAhFpbYfL7Q==",
           "dev": true,
           "requires": {
-            "ember-rfc176-data": "^0.3.6"
+            "ember-rfc176-data": "^0.3.10"
           }
         },
         "broccoli-funnel": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.1.tgz",
-          "integrity": "sha512-C8Lnp9TVsSSiZMGEF16C0dCiNg2oJqUKwuZ1K4kVC6qRPG/2Cj/rtB5kRCC9qEbwqhX71bDbfHROx0L3J7zXQg==",
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
+          "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
           "dev": true,
           "requires": {
             "array-equal": "^1.0.0",
@@ -4890,15 +4890,15 @@
           }
         },
         "ember-rfc176-data": {
-          "version": "0.3.6",
-          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.6.tgz",
-          "integrity": "sha512-kPY94VCukPUPj+/6sZ9KvphD42KnpX2IS31p5z07OFVIviDogR0cQuld5c7Irzfgq7a0YACj0HlToROFn7dLYQ==",
+          "version": "0.3.10",
+          "resolved": "https://registry.npmjs.org/ember-rfc176-data/-/ember-rfc176-data-0.3.10.tgz",
+          "integrity": "sha512-f5a+k+0TmuPaeB8LcmR3Ann3yggBoOp2PLW/rQbUlJoVWCVTNg1w5RnVKYcU02X3+8NagFq8tPJq1yL8QJR5KQ==",
           "dev": true
         },
         "semver": {
-          "version": "5.6.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         }
       }
@@ -6659,9 +6659,9 @@
       }
     },
     "ember-compatibility-helpers": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.1.2.tgz",
-      "integrity": "sha512-yN163MzERpotO8M0b+q+kXs4i3Nx6aIriiZHWv+yXQzr2TAtYlVwg9V7/3+jcurOa3oDEYDpN7y9UZ6q3mnoTg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ember-compatibility-helpers/-/ember-compatibility-helpers-1.2.0.tgz",
+      "integrity": "sha512-pUW4MzJdcaQtwGsErYmitFRs0rlCYBAnunVzlFFUBr4xhjlCjgHJo0b53gFnhTgenNM3d3/NqLarzRhDTjXRTg==",
       "dev": true,
       "requires": {
         "babel-plugin-debug-macros": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "devDependencies": {
     "broccoli-asset-rev": "^3.0.0",
     "ember-ajax": "^4.0.0",
-    "ember-angle-bracket-invocation-polyfill": "^1.2.3",
+    "ember-angle-bracket-invocation-polyfill": "^1.3.1",
     "ember-cli": "~3.8.0",
     "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-eslint": "^5.0.0",

--- a/tests/integration/components/test-namespacing-test.js
+++ b/tests/integration/components/test-namespacing-test.js
@@ -217,7 +217,8 @@ module('test-namespacing', function(hooks) {
       assert.equal(find('*').textContent.trim(), 'hi');
     });
 
-    test('it can render an angle bracket component', async function(assert) {
+    // cannot pass due to ember-angle-bracket-invocation-polyfill adding support for `::` meaning nested
+    skip('it can render an angle bracket component', async function(assert) {
       await render(hbs`<OtherNamespace::SomeJsThing>hi</OtherNamespace::SomeJsThing>`);
 
       assert.equal(find('*').textContent.trim(), 'hi');

--- a/tests/integration/components/test-namespacing-test.js
+++ b/tests/integration/components/test-namespacing-test.js
@@ -3,7 +3,7 @@ import { helper as buildHelper } from '@ember/component/helper';
 import { default as Service, inject } from '@ember/service';
 
 import Component from '@ember/component';
-import { module, test } from 'qunit';
+import { module, test, skip } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
 import hbs from 'htmlbars-inline-precompile';
@@ -14,14 +14,28 @@ define('other-namespace/services/some-service', ['exports'], function(exports) {
   });
 });
 
-define('other-namespace/templates/components/some-service-thing', ['exports'], function(exports) {
+define('other-namespace/templates/components/some-dollar-service-thing', ['exports'], function(exports) {
   exports.default = hbs`{{someService.text}}`;
 });
 
-define('other-namespace/components/some-service-thing', ['exports'], function(exports) {
+define('other-namespace/components/some-dollar-service-thing', ['exports'], function(exports) {
+  exports.default = Component.extend({
+    someService: inject('other-namespace$some-service'),
+  });
+});
+
+define('other-namespace/templates/components/some-colon-service-thing', ['exports'], function(exports) {
+  exports.default = hbs`{{someService.text}}`;
+});
+
+define('other-namespace/components/some-colon-service-thing', ['exports'], function(exports) {
   exports.default = Component.extend({
     someService: inject('other-namespace::some-service'),
   });
+});
+
+define('other-namespace/templates/components/some-nested/template-thing', ['exports'], function(exports) {
+  exports.default = hbs`some-nested-template-thing`;
 });
 
 define('other-namespace/templates/components/some-template-thing', ['exports'], function(exports) {
@@ -61,69 +75,193 @@ define('other-namespace/helpers/some-helper-thing', ['exports'], function(export
 module('test-namespacing', function(hooks) {
   setupRenderingTest(hooks);
 
-  test('it can render a helper', async function(assert) {
-    await render(hbs`{{other-namespace::some-helper-thing 'hi'}}`);
+  module('$ scoping', function() {
+    test('it can render a helper', async function(assert) {
+      await render(hbs`{{other-namespace$some-helper-thing 'hi'}}`);
 
-    assert.equal(find('*').textContent.trim(), 'hi');
-  });
+      assert.equal(find('*').textContent.trim(), 'hi');
+    });
 
-  test('it can render a template only component', async function(assert) {
-    await render(hbs`{{other-namespace::some-template-thing derp="here"}}`);
+    test('it can render a template only component', async function(assert) {
+      await render(hbs`{{other-namespace$some-template-thing derp="here"}}`);
 
-    assert.equal(find('*').textContent.trim(), 'some-template-thing');
-  });
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
 
-  test('it can render a JS only component', async function(assert) {
-    await render(hbs`{{#other-namespace::some-js-thing}}hi{{/other-namespace::some-js-thing}}`);
+    test('it can render a JS only component', async function(assert) {
+      await render(hbs`{{#other-namespace$some-js-thing}}hi{{/other-namespace$some-js-thing}}`);
 
-    assert.equal(find('*').textContent.trim(), 'hi');
-  });
+      assert.equal(find('*').textContent.trim(), 'hi');
+    });
 
-  test('it can render an angle bracket component', async function(assert) {
-    await render(hbs`<OtherNamespace::SomeJsThing>hi</OtherNamespace::SomeJsThing>`);
+    test('it can render an angle bracket component', async function(assert) {
+      await render(hbs`<OtherNamespace$SomeJsThing>hi</OtherNamespace$SomeJsThing>`);
 
-    assert.equal(find('*').textContent.trim(), 'hi');
-  });
+      assert.equal(find('*').textContent.trim(), 'hi');
+    });
 
-  test('it can render service injection', async function(assert) {
-    await render(hbs`{{other-namespace::some-service-thing}}`);
+    // this should be unskipped when we no longer process both `::` and `$` sigils, currently
+    // it is impossible to guarantee that nested component invocation actually works because we supported `::` in
+    // angle brackets
+    skip('it can render a nested angle bracket component', async function(assert) {
+      await render(hbs`<OtherNamespace$SomeNested::TemplateThing>hi</OtherNamespace$SomeNested::TemplateThing>`);
 
-    assert.equal(find('*').textContent.trim(), 'some random text');
-  });
+      assert.equal(find('*').textContent.trim(), 'some-nested-template-thing');
+    });
 
-  test('it can render dynamic component', async function(assert) {
-    this.dynamicName = "other-namespace::some-service-thing";
-    await render(hbs`{{component dynamicName}}`);
+    test('it can render service injection', async function(assert) {
+      await render(hbs`{{other-namespace$some-dollar-service-thing}}`);
 
-    assert.equal(find('*').textContent.trim(), 'some random text');
-  });
+      assert.equal(find('*').textContent.trim(), 'some random text');
+    });
 
-  test('it can render component helper with static name', async function(assert) {
-    await render(hbs`{{component "other-namespace::some-service-thing"}}`);
+    test('it can render dynamic component', async function(assert) {
+      this.dynamicName = "other-namespace$some-dollar-service-thing";
+      await render(hbs`{{component dynamicName}}`);
 
-    assert.equal(find('*').textContent.trim(), 'some random text');
-  });
+      assert.equal(find('*').textContent.trim(), 'some random text');
+    });
 
-  test('it can render component helper with expression', async function(assert) {
-    await render(hbs`
+    test('it can render component helper with static name', async function(assert) {
+      await render(hbs`{{component "other-namespace$some-dollar-service-thing"}}`);
+
+      assert.equal(find('*').textContent.trim(), 'some random text');
+    });
+
+    test('it can render component helper with expression', async function(assert) {
+      await render(hbs`
       {{component
-        (other-namespace::some-helper-thing "other-namespace::some-service-thing")
+        (other-namespace$some-helper-thing "other-namespace$some-dollar-service-thing")
       }}
     `);
 
-    assert.equal(find('*').textContent.trim(), 'some random text');
-  });
+      assert.equal(find('*').textContent.trim(), 'some random text');
+    });
 
-  test('it can render component helper in block mode with static name', async function(assert) {
-    await render(hbs`{{#component "other-namespace::some-yield-static" as |cmpt|}}
+    test('it can render component helper in block mode with static name', async function(assert) {
+      await render(hbs`{{#component "other-namespace$some-yield-static" as |cmpt|}}
                        {{component cmpt}}
                      {{/component}}`);
 
-    assert.equal(find('*').textContent.trim(), 'some-template-thing');
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
+
+    test('it can render component helper in block mode with expression', async function(assert) {
+      await render(hbs`
+      {{#component
+        (other-namespace$some-helper-thing "other-namespace$some-yield-static")
+        as |cmpt|}}
+        {{component cmpt}}
+      {{/component}}
+    `);
+
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
+
+    test('it can render component helper in block mode with dynamic name', async function(assert) {
+      this.dynamicName = 'other-namespace$some-yield-static';
+      await render(hbs`{{#component dynamicName as |cmpt|}}
+                       {{component cmpt}}
+                     {{/component}}`);
+
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
+
+    test('it can yield component with dynamic name', async function(assert) {
+      await render(
+        hbs`{{#other-namespace$some-yield-dynamic dynamicName="other-namespace$some-template-thing" as |cmpt|}}
+            {{component cmpt}}
+          {{/other-namespace$some-yield-dynamic}}`
+      );
+
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
+
+    test('it can yield component with static name', async function(assert) {
+      await render(
+        hbs`{{#other-namespace$some-yield-static  as |cmpt|}}
+            {{component cmpt}}
+          {{/other-namespace$some-yield-static}}`
+      );
+
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
+
+    test('it can yield component with expression', async function(assert) {
+      await render(
+        hbs`{{#other-namespace$some-yield-helper  as |cmpt|}}
+            {{component cmpt}}
+          {{/other-namespace$some-yield-helper}}`
+      );
+
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
   });
 
-  test('it can render component helper in block mode with expression', async function(assert) {
-    await render(hbs`
+  module(':: scoping [deprecated]', function() {
+    test('it can render a helper', async function(assert) {
+      await render(hbs`{{other-namespace::some-helper-thing 'hi'}}`);
+
+      assert.equal(find('*').textContent.trim(), 'hi');
+    });
+
+    test('it can render a template only component', async function(assert) {
+      await render(hbs`{{other-namespace::some-template-thing derp="here"}}`);
+
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
+
+    test('it can render a JS only component', async function(assert) {
+      await render(hbs`{{#other-namespace::some-js-thing}}hi{{/other-namespace::some-js-thing}}`);
+
+      assert.equal(find('*').textContent.trim(), 'hi');
+    });
+
+    test('it can render an angle bracket component', async function(assert) {
+      await render(hbs`<OtherNamespace::SomeJsThing>hi</OtherNamespace::SomeJsThing>`);
+
+      assert.equal(find('*').textContent.trim(), 'hi');
+    });
+
+    test('it can render service injection', async function(assert) {
+      await render(hbs`{{other-namespace::some-colon-service-thing}}`);
+
+      assert.equal(find('*').textContent.trim(), 'some random text');
+    });
+
+    test('it can render dynamic component', async function(assert) {
+      this.dynamicName = "other-namespace::some-colon-service-thing";
+      await render(hbs`{{component dynamicName}}`);
+
+      assert.equal(find('*').textContent.trim(), 'some random text');
+    });
+
+    test('it can render component helper with static name', async function(assert) {
+      await render(hbs`{{component "other-namespace::some-colon-service-thing"}}`);
+
+      assert.equal(find('*').textContent.trim(), 'some random text');
+    });
+
+    test('it can render component helper with expression', async function(assert) {
+      await render(hbs`
+      {{component
+        (other-namespace::some-helper-thing "other-namespace::some-colon-service-thing")
+      }}
+    `);
+
+      assert.equal(find('*').textContent.trim(), 'some random text');
+    });
+
+    test('it can render component helper in block mode with static name', async function(assert) {
+      await render(hbs`{{#component "other-namespace::some-yield-static" as |cmpt|}}
+                       {{component cmpt}}
+                     {{/component}}`);
+
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
+
+    test('it can render component helper in block mode with expression', async function(assert) {
+      await render(hbs`
       {{#component
         (other-namespace::some-helper-thing "other-namespace::some-yield-static")
         as |cmpt|}}
@@ -131,45 +269,46 @@ module('test-namespacing', function(hooks) {
       {{/component}}
     `);
 
-    assert.equal(find('*').textContent.trim(), 'some-template-thing');
-  });
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
 
-  test('it can render component helper in block mode with dynamic name', async function(assert) {
-    this.dynamicName = 'other-namespace::some-yield-static';
-    await render(hbs`{{#component dynamicName as |cmpt|}}
+    test('it can render component helper in block mode with dynamic name', async function(assert) {
+      this.dynamicName = 'other-namespace::some-yield-static';
+      await render(hbs`{{#component dynamicName as |cmpt|}}
                        {{component cmpt}}
                      {{/component}}`);
 
-    assert.equal(find('*').textContent.trim(), 'some-template-thing');
-  });
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
 
-  test('it can yield component with dynamic name', async function(assert) {
-    await render(
-      hbs`{{#other-namespace::some-yield-dynamic dynamicName="other-namespace::some-template-thing" as |cmpt|}}
+    test('it can yield component with dynamic name', async function(assert) {
+      await render(
+        hbs`{{#other-namespace::some-yield-dynamic dynamicName="other-namespace::some-template-thing" as |cmpt|}}
             {{component cmpt}}
           {{/other-namespace::some-yield-dynamic}}`
-    );
+      );
 
-    assert.equal(find('*').textContent.trim(), 'some-template-thing');
-  });
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
 
-  test('it can yield component with static name', async function(assert) {
-    await render(
-      hbs`{{#other-namespace::some-yield-static  as |cmpt|}}
+    test('it can yield component with static name', async function(assert) {
+      await render(
+        hbs`{{#other-namespace::some-yield-static  as |cmpt|}}
             {{component cmpt}}
           {{/other-namespace::some-yield-static}}`
-    );
+      );
 
-    assert.equal(find('*').textContent.trim(), 'some-template-thing');
-  });
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
 
-  test('it can yield component with expression', async function(assert) {
-    await render(
-      hbs`{{#other-namespace::some-yield-helper  as |cmpt|}}
+    test('it can yield component with expression', async function(assert) {
+      await render(
+        hbs`{{#other-namespace::some-yield-helper  as |cmpt|}}
             {{component cmpt}}
           {{/other-namespace::some-yield-helper}}`
-    );
+      );
 
-    assert.equal(find('*').textContent.trim(), 'some-template-thing');
+      assert.equal(find('*').textContent.trim(), 'some-template-thing');
+    });
   });
 });

--- a/vendor/service-inject.js
+++ b/vendor/service-inject.js
@@ -4,7 +4,8 @@
   var ORIGINAL_INJECT_SERVICE = Ember.inject.service;
   // eslint-disable-next-line ember/new-module-imports
   Ember.inject.service = function(_name) {
-    var name = _name === undefined ? undefined : _name.replace('::', '@');
+    var name = _name === undefined ? undefined : _name.replace('::', '@').replace('$', '@');
+
     return ORIGINAL_INJECT_SERVICE.call(this, name);
   };
 })();


### PR DESCRIPTION
Since Ember has decided to repurpose the `::` sigil to mean "nested folder invocation" (see emberjs/rfcs#457), this introduces `$` as a replacement sigil. Ultimately, usage of `::` will be deprecated by this addon (though that will be in a future commit).

Implements part of #202