### PR TITLE
fix(service): propagate original args into original inject fn

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   root: true,
+  parser: "babel-eslint",
   parserOptions: {
     ecmaVersion: 2018,
     sourceType: 'module'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1714,6 +1714,20 @@
         }
       }
     },
+    "babel-eslint": {
+      "version": "10.0.3",
+      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-10.0.3.tgz",
+      "integrity": "sha512-z3U7eMY6r/3f3/JB9mTsLjyxrv0Yb1zb8PCWCLpguxfCzBIZUwy23R1t/XKewP+8mEN2Ck8Dtr4q20z6ce6SoA==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "@babel/parser": "^7.0.0",
+        "@babel/traverse": "^7.0.0",
+        "@babel/types": "^7.0.0",
+        "eslint-visitor-keys": "^1.0.0",
+        "resolve": "^1.12.0"
+      }
+    },
     "babel-generator": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-version-checker": "^3.0.1"
   },
   "devDependencies": {
+    "babel-eslint": "^10.0.3",
     "ember-angle-bracket-invocation-polyfill": "^2.0.2",
     "ember-cli": "~3.13.0",
     "ember-cli-dependency-checker": "^3.2.0",

--- a/tests/unit/services/namespaced-services-test.js
+++ b/tests/unit/services/namespaced-services-test.js
@@ -21,4 +21,14 @@ module('Unit | Service | namespaced-services', function(hooks) {
 
     assert.equal(service.get('someService').sayHi(), 'hi!');
   });
+
+  test('doesn\'t break services injected using decorators', function (assert) {
+    this.owner.register('service:subject', class Subject extends Service {
+      @inject('other-namespace$some-thing') bar;
+    });
+
+    let service = this.owner.lookup('service:subject');
+
+    assert.equal(service.get('bar').sayHi(), 'hi!');
+  })
 });

--- a/vendor/service-inject-3.js
+++ b/vendor/service-inject-3.js
@@ -1,13 +1,21 @@
 /* globals Ember */
 /* eslint-disable ember/new-module-imports */
 
+const { isElementDescriptor } = Ember.__loader.require('@ember/-internals/metal');
+
 (function() {
-  var ORIGINAL_INJECT_SERVICE = Ember.inject.service;
-  Ember.inject.service = function(name) {
-    if (name === undefined) {
-      return ORIGINAL_INJECT_SERVICE.call(this, name);
+  const ORIGINAL_INJECT_SERVICE = Ember.inject.service;
+  Ember.inject.service = function(...args) {
+    const resolvedName = isElementDescriptor(args) ? undefined : args[0];
+
+    if (resolvedName === undefined) {
+      return ORIGINAL_INJECT_SERVICE.call(this, ...args);
     }
 
-    return ORIGINAL_INJECT_SERVICE.call(this, name.replace('$', '@'));
+    const mutatedName = resolvedName.replace('$', '@');
+    const mutatedArgs = args.slice();
+    mutatedArgs.splice(mutatedArgs.indexOf(resolvedName), 1, mutatedName);
+
+    return ORIGINAL_INJECT_SERVICE.call(this, ...mutatedArgs);
   };
 })();


### PR DESCRIPTION
Not sure if this is correct in all cases, but think it should resolve this addon breaking decorator functionality.