### PR TITLE
Fix dependency check of ember-resolver in project

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = {
   init() {
     this._super.init.apply(this, arguments);
 
-    let checker = new VersionChecker(this);
+    let checker = new VersionChecker(this.project);
 
     checker.for('ember-resolver').assertAbove('4.5.0', 'To use ember-holy-futuristic-template-namespacing-batman you must have ember-resolver@4.5.0');
   },


### PR DESCRIPTION
Currently the addon is looking for ember-resolver within itself. Since
ember-resolver is most of the times (if not always) a devDependency, it
causes issues when using `npm link` or `yarn link` with addons that use
this addon.

When using `this.project`, we are confirming that the version of
`ember-checker` is correct at the project level, because it is expected
to be a project dependency.