### PR TITLE
Remove ember-cli-htmlbars-inline-precompile.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2978,12 +2978,6 @@
         "lodash": "^4.17.11"
       }
     },
-    "babel-plugin-htmlbars-inline-precompile": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-htmlbars-inline-precompile/-/babel-plugin-htmlbars-inline-precompile-1.0.0.tgz",
-      "integrity": "sha512-4jvKEHR1bAX03hBDZ94IXsYCj3bwk9vYsn6ux6JZNL2U5pvzCWjqyrGahfsGNrhERyxw8IqcirOi9Q6WCo3dkQ==",
-      "dev": true
-    },
     "babel-plugin-module-resolver": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-module-resolver/-/babel-plugin-module-resolver-3.2.0.tgz",
@@ -6863,31 +6857,6 @@
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
             "matcher-collection": "^2.0.0"
-          }
-        }
-      }
-    },
-    "ember-cli-htmlbars-inline-precompile": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ember-cli-htmlbars-inline-precompile/-/ember-cli-htmlbars-inline-precompile-2.1.0.tgz",
-      "integrity": "sha512-BylIHduwQkncPhnj0ZyorBuljXbTzLgRo6kuHf1W+IHFxThFl2xG+r87BVwsqx4Mn9MTgW9SE0XWjwBJcSWd6Q==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-htmlbars-inline-precompile": "^1.0.0",
-        "ember-cli-version-checker": "^2.1.2",
-        "hash-for-dep": "^1.2.3",
-        "heimdalljs-logger": "^0.1.9",
-        "silent-error": "^1.1.0"
-      },
-      "dependencies": {
-        "ember-cli-version-checker": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/ember-cli-version-checker/-/ember-cli-version-checker-2.2.0.tgz",
-          "integrity": "sha512-G+KtYIVlSOWGcNaTFHk76xR4GdzDLzAS4uxZUKdASuFX0KJE43C6DaqL+y3VTpUFLI2FIkAS6HZ4I1YBi+S3hg==",
-          "dev": true,
-          "requires": {
-            "resolve": "^1.3.3",
-            "semver": "^5.3.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "ember-cli-dependency-checker": "^3.2.0",
     "ember-cli-eslint": "^5.1.0",
     "ember-cli-htmlbars": "^4.2.0",
-    "ember-cli-htmlbars-inline-precompile": "^2.1.0",
     "ember-cli-inject-live-reload": "^2.0.2",
     "ember-cli-qunit": "^4.1.1",
     "ember-disable-prototype-extensions": "^1.1.2",

--- a/tests/integration/components/test-namespacing-test.js
+++ b/tests/integration/components/test-namespacing-test.js
@@ -6,7 +6,7 @@ import Component from '@ember/component';
 import { module, test } from 'qunit';
 import { setupRenderingTest } from 'ember-qunit';
 import { render, find } from '@ember/test-helpers';
-import hbs from 'htmlbars-inline-precompile';
+import { hbs } from 'ember-cli-htmlbars';
 
 define('other-namespace/services/some-service', ['exports'], function(exports) {
   exports.default = Service.extend({


### PR DESCRIPTION
Now that we have updated to ember-cli-htmlbars@4, inline precompilation support is part of ember-cli-htmlbars. We can remove the ember-cli-htmlbars-inline-precompile package and update our import paths to `import {hbs} from 'ember-cli-htmlbars'`.