### PR TITLE
Add support for 'excludeNestedAddonTransforms' configuration setting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,14 @@
 'use strict';
 
 const VersionChecker = require('ember-cli-version-checker');
+const SilentError = require('silent-error');
+
+function inertPlugin() {
+  return {
+    name: 'holy-futuristic-template-namespacing-batman:noop',
+    visitor: {},
+  };
+}
 
 module.exports = {
   name: 'ember-holy-futuristic-template-namespacing-batman',
@@ -17,30 +25,79 @@ module.exports = {
     }
   },
 
-  setupPreprocessorRegistry(type, registry) {
-    let dollarPluginObj = this._buildDollarPlugin();
-    dollarPluginObj.parallelBabel = {
-      requireFile: __filename,
-      buildUsing: '_buildDollarPlugin',
-      params: {}
+  _shouldBeInert() {
+    if (this.parent === this.project) {
+      // If we're a top-level addon, we're never inert
+      return false;
     }
+
+    const addon = this.project && this.project.addons.find(a => Boolean(a.app));
+    const options = addon && addon.app.options['ember-holy-futuristic-template-namespacing-batman'] || {};
+
+    return Boolean(options.excludeNestedAddonTransforms);
+  },
+
+  setupPreprocessorRegistry(type, registry) {
+    const addon = this;
+    const dollarPluginObj = {
+      name: 'holy-futuristic-template-namespacing-batman',
+      get plugin() {
+        if (addon._shouldBeInert()) {
+          return inertPlugin;
+        }
+
+        return require('./lib/namespacing-transform').DollarNamespacingTransform;
+      },
+      baseDir: function() {
+        return __dirname;
+      },
+      parallelBabel: {
+        requireFile: __filename,
+        get buildUsing() {
+          return addon._shouldBeInert() ? '_buildInertPlugin' : '_buildDollarPlugin';
+        },
+      },
+    };
 
     registry.add("htmlbars-ast-plugin", dollarPluginObj);
   },
 
   _buildDollarPlugin() {
+    // Used only when parallelizing the build
     return {
       name: 'holy-futuristic-template-namespacing-batman',
-      plugin: require("./lib/namespacing-transform").DollarNamespacingTransform,
+      plugin: require('./lib/namespacing-transform').DollarNamespacingTransform,
       baseDir: function() {
         return __dirname;
-      }
+      },
+    };
+  },
+
+  _buildInertPlugin() {
+    // Used when parallelized and doing nothing
+    return {
+      name: 'holy-futuristic-template-namespacing-batman',
+      plugin: inertPlugin,
+      baseDir: function () {
+        return __dirname;
+      },
     };
   },
 
   included() {
     this._super.included.apply(this, arguments);
 
-    this.import('vendor/service-inject-3.js');
-  }
+    if (this._shouldBeInert()) {
+      // This addon is included as a transitive dep _and_ excludeNestedAddonTransforms is set
+      // Check if there is a top-level copy of this addon and error if not
+      const topLevelAddon = this.project.addons.find(a => a.name === this.name);
+      if (!topLevelAddon) {
+        throw new SilentError(
+          "You must have ember-holy-futuristic-template-namespacing-batman installed in the root App if you enable the 'excludeNestedAddonTransforms' option."
+        );
+      }
+    } else {
+      this.import('vendor/service-inject-3.js');
+    }
+  },
 };

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
   },
   "dependencies": {
     "ember-cli-babel": "^7.13.2",
-    "ember-cli-version-checker": "^5.1.1"
+    "ember-cli-version-checker": "^5.1.1",
+    "silent-error": "^1.1.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",


### PR DESCRIPTION
Info
-----
* By default, this addon always applies its transformations, even if it is a nested dependency within a larger application.
* However, for some builds (e.g. [embroider](https://github.com/embroider-build/embroider)), nested addons are transpiled source-to-source.
* The handlebars source-code output with this transformation outputs invalid handlebars syntax, so we want to be able to disable the transform in those situations.
* In order for that to work, the top-level App must _also_ include this addon, so that it will eventually be applied.

Changes
-----
* Added an `excludeNestedAddonTransforms` configuration that will disable template AST transformations for any copies of this addon except the one included by the root app.
* Set up the `parallelBabel` to correctly use either the real or noop transformation (hat tip to @rwjblue)
* Added an error condition if the flag is set but the top-level app doesn't include this addon itself.

Tested
-----
* Confirmed that an embroider app utilizing source-to-source transpilation works correctly with the flag enabled.
* Verified locally that the error is shown if this flag is set but the top-level app doesn't include the addon.
* Linting and tests pass.