### PR TITLE
Include no-op status in the cache key for the AST plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -51,6 +51,9 @@ module.exports = {
       baseDir: function() {
         return __dirname;
       },
+      cacheKey: function() {
+        return addon._shouldBeInert() ? 'noop' : 'transform';
+      },
       parallelBabel: {
         requireFile: __filename,
         get buildUsing() {


### PR DESCRIPTION
Info
-----
* With the addition of the `excludeNestedAddonTransforms` option, the effect of the AST plugin can change from run to run as that option is changed.
* Currently, there is no custom cache key provided, so the transformation is always cached the same, regardless of whether it is an operative plugin or a no-op.
* This can cause hard-to-debug failures where an invalid cache is re-used.

Changes
-----
* Added a `cacheKey` method to the registered plugin, switching the key based on the `_shouldBeInert()` setting.

Tested
-----
* Local testing with an project using `ember-try` to confirm the cache is properly invalidated when the setting changes.