### PR TITLE
Fix usage of `{{component 'some-string'}}` under Embroider (re-export the dynamic component helper into `app`)

### DIFF
--- a/app/helpers/ember-holy-futuristic-template-namespacing-batman-translate-dynamic-2.js
+++ b/app/helpers/ember-holy-futuristic-template-namespacing-batman-translate-dynamic-2.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-holy-futuristic-template-namespacing-batman/helpers/-translate-dynamic-2';

--- a/lib/namespacing-transform.js
+++ b/lib/namespacing-transform.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const TRANSLATE_HELPER = 'ember-holy-futuristic-template-namespacing-batman@-translate-dynamic-2';
+const TRANSLATE_HELPER = 'ember-holy-futuristic-template-namespacing-batman-translate-dynamic-2';
 
 function rewriteOrWrapComponentParam(node, b, sigil) {
   if (!node.params.length) {


### PR DESCRIPTION
Fixes an issue where Embroider cannot find the helper when staticHelpers is enabled.