### PR TITLE
Avoid erroring while in `.gjs` / `.gts` files (e.g. strict mode)

### DIFF
--- a/lib/namespacing-transform.js
+++ b/lib/namespacing-transform.js
@@ -21,6 +21,13 @@ function emberHolyFuturisticNamespacingBatmanTransform(env)  {
   let sigil = '$';
   let b = env.syntax.builders;
 
+  if (env.strictMode) {
+    return {
+      name: 'ember-holy-futuristic-template-namespacing-batman:strict-mode-namespacing-transform',
+      visitor: {}
+    };
+  }
+
   return {
     name: 'ember-holy-futuristic-template-namespacing-batman:namespacing-transform',
 


### PR DESCRIPTION
fixes #540 and the error:
```
Error: Attempted to resolve a helper in a strict mode template, but that value was not in scope: ember-holy-futuristic-template-namespacing-batman-translate-dynamic-2
```

